### PR TITLE
Adds ipfs-postmsg-proxy to expose ipfs node running in service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+examples/use-from-another-page/public+sw/bundle.js
 examples/use-from-another-page/public+sw/service-worker-bundle.js

--- a/README.md
+++ b/README.md
@@ -11,12 +11,78 @@
 ![](https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square)
 ![](https://img.shields.io/badge/Node.js-%3E%3D4.0.0-orange.svg?style=flat-square)
 
-> Run an IPFS node inside a service worker and serve all your IPFS Urls directly from IPFS! 
+> Run an IPFS node inside a service worker and serve all your IPFS Urls directly from IPFS!
 
-# BEWARE BEWARE there may be dragons! 🐉
+## BEWARE BEWARE there may be dragons! 🐉
 
-This module is still experimental because it is indeed an experiment part of the https://github.com/ipfs/in-web-browsers endeavour. 
+This module is still experimental because it is indeed an experiment part of the https://github.com/ipfs/in-web-browsers endeavour.
 
-# Usage
+## Usage
 
-This module requires `js-ipfs v0.24.0 or higher`
+This project is a how to, that you can use as a basis for building an application with `js-ipfs` (`>=0.24.0`) running in a service worker.
+
+Note, the following code snippets are edited from the actual source code for brevity.
+
+### Service worker code
+
+The service worker code lives in `src/index.js`. This is the code that will run as a service worker. It boots up an IPFS node, responds to requests and exposes the running node for use by web pages within the scope of the service worker.
+
+The IPFS node is created when the service worker ['activate' event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/onactivate) is fired:
+
+```js
+const IPFS = require('ipfs')
+
+self.addEventListener('activate', () => {
+  ipfs = new IPFS({ /* ...config... */ })
+})
+```
+
+The service worker listens for ['fetch' events](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent) so that it can [respond](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response) to requests:
+
+```js
+self.addEventListener('fetch', (event) => {
+  const hash = event.request.url.split('/ipfs/')[1]
+  event.respondWith(catAndRespond(hash))
+})
+
+async function catAndRespond (hash) {
+  const data = await ipfs.files.cat(hash)
+  return new Response(data, { status: 200, statusText: 'OK', headers: {} })
+}
+```
+
+Finally, the IPFS node is exposed for use by web pages/apps. Service workers are permitted to talk to web pages via a messaging API so we can use [`ipfs-postmsg-proxy`](https://github.com/tableflip/ipfs-postmsg-proxy) to talk to the IPFS node running in the worker. We create a "proxy server" for this purpose:
+
+```js
+const { createProxyServer } = require('ipfs-postmsg-proxy')
+// Setup a proxy server that talks to our real IPFS node
+createProxyServer(() => ipfs, { /* ...config... */ })
+```
+
+### Application code
+
+The application code lives in `examples/use-from-another-page/public+sw`. It registers the service worker and talks to the IPFS node that runs in it.
+
+First we feature detect that the client's browser supports service workers, and then we [register the service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register).
+
+```js
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker-bundle.js')
+    .then((reg) => console.log('Successful service worker register'))
+    .catch((err) => console.error('Failed service worker register', err))
+}
+```
+
+Once the service worker is registered, we can start talking to the IPFS node that it is running. To do this we create a "proxy client" which can talk to our "proxy server" over the messaging API:
+
+```js
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker-bundle.js')
+    .then(async () => {
+      ipfs = createProxyClient({ /* ...config... */ })
+
+      // Now use `ipfs` as usual! e.g.
+      const { agentVersion, id } = await ipfs.id()
+    })
+}
+```

--- a/examples/use-from-another-page/package.json
+++ b/examples/use-from-another-page/package.json
@@ -9,8 +9,11 @@
   },
   "author": "David Dias <mail@daviddias.me>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "ipfs-postmsg-proxy": "^2.3.0"
+  },
   "devDependencies": {
+    "standard": "^10.0.3",
     "webpack": "^2.5.1"
   }
 }

--- a/examples/use-from-another-page/public+sw/index.html
+++ b/examples/use-from-another-page/public+sw/index.html
@@ -3,8 +3,7 @@
 <body>
   <h1>js-ipfs in a service worker</h1>
   <textarea id="input" cols="100"></textarea>
-  <button id="show">Fetch</button>
+  <button id="show">Fetch</button> <button id="id">Get window.ipfs.id</button>
   <div id="display"></div>
-  <script src="index.js"></script>
-  <script src="service-worker-bundle.js"></script>
+  <script src="bundle.js"></script>
 </body>

--- a/examples/use-from-another-page/public+sw/index.js
+++ b/examples/use-from-another-page/public+sw/index.js
@@ -1,14 +1,29 @@
 'use strict'
 
+const { createProxyClient } = require('ipfs-postmsg-proxy')
+let node
+
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('service-worker-bundle.js')
     .then((registration) => {
       console.log('-> Registered the service worker successfuly')
+
+      node = createProxyClient({
+        addListener: navigator.serviceWorker.addEventListener.bind(navigator.serviceWorker),
+        removeListener: navigator.serviceWorker.removeEventListener.bind(navigator.serviceWorker),
+        postMessage: (data) => navigator.serviceWorker.controller.postMessage(data)
+      })
     })
     .catch((err) => {
       console.log('-> Failed to register:', err)
     })
 }
+
+document.querySelector('#id').addEventListener('click', async () => {
+  if (!node) return alert('Service worker not registered')
+  const { agentVersion, id } = await node.id()
+  alert(`${agentVersion} ${id}`)
+})
 
 document.querySelector('#show').addEventListener('click', () => {
   const multihash = document.querySelector('#input').value

--- a/examples/use-from-another-page/webpack.config.js
+++ b/examples/use-from-another-page/webpack.config.js
@@ -1,7 +1,10 @@
 module.exports = {
-  entry: './src/index.js',
+  entry: {
+    'service-worker-bundle': './src/index.js',
+    bundle: './public+sw/index.js'
+  },
   output: {
-    filename: 'public+sw/service-worker-bundle.js'
+    filename: 'public+sw/[name].js'
   },
   node: {
     fs: 'empty',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "homepage": "https://github.com/ipfs/ipfs-service-worker#readme",
   "dependencies": {
-    "bl": "^1.2.1",
-    "ipfs": "^0.23.1"
+    "ipfs": "^0.27.7",
+    "ipfs-postmsg-proxy": "^2.3.0"
+  },
+  "devDependencies": {
+    "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
![feb-09-2018 09-27-39](https://user-images.githubusercontent.com/152863/36020806-d13fe726-0d7b-11e8-9f2c-fc7328ad8dea.gif)

**What is this?**

The IPFS node is running in the service worker. It is set up to hijack (respond to) requests that are for IPFS paths. That is awesome! **However**, you can't use the IPFS node directly 😢 

This PR adds [`ipfs-postmsg-proxy`](https://www.npmjs.com/package/ipfs-postmsg-proxy), which exposes the IPFS node running in the service worker to the page that registered the worker.

So...the page can just call `ipfs.id`, `ipfs.cat`, `ipfs.add` etc.

---

This PR simply adds a button to the example that calls `ipfs.id` when pressed.


