### PR TITLE
Initialization and webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ jspm_packages
 .node_repl_history
 examples/use-from-another-page/public+sw/bundle.js
 examples/use-from-another-page/public+sw/service-worker-bundle.js
+examples/use-from-another-page/dist

--- a/README.md
+++ b/README.md
@@ -86,3 +86,12 @@ if ('serviceWorker' in navigator) {
     })
 }
 ```
+### Installation and testing
+
+* Clone the repo from here
+* cd to ipfs-service-worker
+* npm install
+* cd examples
+* npm run build
+* cp -r public+sw/* dist/public+sw
+

--- a/examples/use-from-another-page/package.json
+++ b/examples/use-from-another-page/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack"
+    "build": "webpack",
+    "builddev": "webpack -w --mode development",
   },
   "author": "David Dias <mail@daviddias.me>",
   "license": "MIT",
@@ -14,6 +15,6 @@
   },
   "devDependencies": {
     "standard": "^10.0.3",
-    "webpack": "^2.5.1"
+    "webpack": "^4.2.0",
   }
 }

--- a/examples/use-from-another-page/webpack.config.js
+++ b/examples/use-from-another-page/webpack.config.js
@@ -9,9 +9,17 @@ module.exports = {
   node: {
     fs: 'empty',
     net: 'empty',
-    tls: 'empty'
-  },
-  resolve: {
+    tls: 'empty',
+        crypto: 'empty',
+        process: true,
+        module: false,
+        clearImmediate: false,
+        Buffer: true,
+        setImmediate: false,
+        console: false
+    },
+
+    resolve: {
     alias: {
       zlib: 'browserify-zlib-next'
     }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/ipfs/ipfs-service-worker#readme",
   "dependencies": {
-    "ipfs": "^0.27.7",
-    "ipfs-postmsg-proxy": "^2.3.0"
+    "ipfs": "^0.28.2",
+    "ipfs-postmsg-proxy": "^2.3.0",
   },
   "devDependencies": {
     "standard": "^10.0.3"


### PR DESCRIPTION
This fixes the issues raised in https://github.com/ipfs/ipfs-service-worker/issues/9 specifically.

* Some notes on how to get something running that is testable (this was surprisingly difficult)
* Upgrade to webpack 4.x and js-ipfs 0.28.2 
* Fix a key problem where on the second run, the service worker fails to initialize node to IPFS (according to docs I found you can't rely on Service Workers retaining state between calls). Instead I reconnect to the repository if required on each call.