### PR TITLE
docs(readme): deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ⛔️ DEPRECATED
+
+_This example is out of date and will not be maintained._
+
+This is an old PoC from 2017-2018. 
+
+See the modern end-to-end example of using js-ipfs node in `SharedWorker` from `ServiceWorker` at [`ipfs/js-ipfs/examples/browser-service-worker`](https://github.com/ipfs/js-ipfs/tree/master/examples/browser-service-worker)
+
+
+---
+
+
 # Demo: use `js-ipfs` within a Service Worker
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# ⛔️ DEPRECATED
-
-_This example is out of date and will not be maintained._
-
-This is an old PoC from 2017-2018. 
-
-See the modern end-to-end example of using js-ipfs node in `SharedWorker` from `ServiceWorker` at [`ipfs/js-ipfs/examples/browser-service-worker`](https://github.com/ipfs/js-ipfs/tree/master/examples/browser-service-worker)
-
+> [!CAUTION]
+>
+> # ⛔️ DEPRECATED
+>
+> _This example is out of date and not be maintained anymore._
+>
+> This is an old PoC from 2017-2018.
+>
+> See the modern end-to-end example of using Helia in `ServiceWorker` at <https://github.com/ipfs/service-worker-gateway>
 
 ---
 


### PR DESCRIPTION
> Part of ServiceWorker example cleanup: https://github.com/ipfs/in-web-browsers/issues/171

This repo hosts an old PoC from 2017-2018, better to be clear about this and point any drive-by visitors to the latest examples.

After this is merged, we should move this repo to @ipfs-inactive